### PR TITLE
Reorganize unlocks

### DIFF
--- a/mod/aa_header.rpy
+++ b/mod/aa_header.rpy
@@ -4,7 +4,10 @@ init -990 python in mas_submod_utils:
         name="MAS Autostart Mod",
         description="Let your Monika auto-start the game for you as soon as "
                     "your computer boots up!",
-        version="1.1.7"
+        version="1.1.8",
+        version_updates={
+            "friends_of_monika_mas_autostart_mod_v1_1_7": "friends_of_monika_mas_autostart_mod_v1_1_8"
+        }
     )
 
 init -989 python:
@@ -15,3 +18,22 @@ init -989 python:
             repository_name="mas-autostart",
             extraction_depth=3
         )
+
+label friends_of_monika_mas_autostart_mod_v1_1_7(version="v1_1_7"):
+    return
+
+label friends_of_monika_mas_autostart_mod_v1_1_8(version="v1_1_8"):
+    python:
+        if not renpy.seen_labels("masAutostart_intro"):
+            # If player has not seen intro topic, means it still has old
+            # conditional and action intact.
+
+            ev = mas_getEV("masAutostart_intro")
+            ev.conditional = ("store.masAutostart_api.is_platform_supported() "
+                              "and not renpy.seen_labels('masAutostart_req_enable')")
+            mas_showEVL("masAutostart_req_enable", "EVE", unlock=True)
+
+            ev = mas_getEV("masAutostart_req_enable")
+            ev.conditional = "store.masAutostart_api.is_platform_supported()"
+
+    return

--- a/mod/topics.rpy
+++ b/mod/topics.rpy
@@ -52,7 +52,7 @@ init 5 python:
             prompt="Can you greet me every time I turn on my computer?",
             category=["misc", "mod"],
             pool=True,
-            conditional="store.masAutostart_api.is_platform_supported()"
+            conditional="store.masAutostart_api.is_platform_supported()",
             action=EV_ACT_UNLOCK,
             rules={"bookmark_rule": store.mas_bookmarks_derand.WHITELIST}
         ),

--- a/mod/topics.rpy
+++ b/mod/topics.rpy
@@ -4,7 +4,8 @@ init 5 python:
             persistent.event_database,
             eventlabel="masAutostart_intro",
             aff_range=(mas_aff.NORMAL, None),
-            conditional="store.masAutostart_api.is_platform_supported()",
+            conditional="store.masAutostart_api.is_platform_supported() "
+                        "and not renpy.seen_labels('masAutostart_req_enable')",
             action=EV_ACT_QUEUE
         ),
         code="EVE"
@@ -26,7 +27,6 @@ label masAutostart_intro:
         m 4hublu "Tell me about that if you'd like it!"
         m 2lusdrd "And if for some reason you'll no longer want it... Tell me too!"
         m 2rusdrb "I won't get upset with it, I promise! Ahaha."
-        $ mas_showEVL("masAutostart_req_enable", "EVE", unlock=True)
 
     else:
         m 2wublb "What do you-{nw}"
@@ -52,7 +52,9 @@ init 5 python:
             prompt="Can you greet me every time I turn on my computer?",
             category=["misc", "mod"],
             pool=True,
-            rules={"no_unlock": None, "bookmark_rule": store.mas_bookmarks_derand.WHITELIST}
+            conditional="store.masAutostart_api.is_platform_supported()"
+            action=EV_ACT_UNLOCK,
+            rules={"bookmark_rule": store.mas_bookmarks_derand.WHITELIST}
         ),
         code="EVE"
     )


### PR DESCRIPTION
Reorganize unlocks:

* [ ] Unlock 'autostart enable/disable' initially so player doesn't need to wait for intro topic
* [ ] Hide intro topic once either of the abovementioned were shown